### PR TITLE
Fix example of to / if_true delegation

### DIFF
--- a/lib/Method/Delegation.pm
+++ b/lib/Method/Delegation.pm
@@ -296,14 +296,14 @@ that:
 
     delegate(
         methods => 'current_ship',
-        to      => 'character_ship',
-        if_true => 'character_ship',
+        to      => 'character',
+        if_true => 'character',
     );
     # equivalent to:
     sub current_ship {
         my $self = shift;
-        if ( $self->character_ship ) {
-            return $self->character_ship;
+        if ( $self->character ) {
+            return $self->character->current_ship;
         }
         return;
     }
@@ -313,7 +313,7 @@ you're delegating to might not exist.
 
     delegate(
         methods  => 'current_ship',
-        maybe_to => 'character_ship',
+        maybe_to => 'character',
     );
 
 Note: the C<if_true> attribute doesn't need to point to the same method, but


### PR DESCRIPTION
While reading the documentation, I found an example that did not look like the rest.

I browsed through the source code and the tests, and I think the sample code was mistaken.

This patch fixes it trying to keep the meaning of it the same.